### PR TITLE
feat: add require into package export

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
We needed as platformatic uses `require.resolve` to get a path to the interceptor module.